### PR TITLE
allow html in radio and checkboxes with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+composer.phar
+composer.lock
+.DS_Store

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
         "illuminate/support": "^5.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4",
-        "orchestra/testbench": "^3.5"
+        "phpunit/phpunit": "^7.0",
+        "orchestra/testbench": "^3.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/Bootstrap/Elements/CheckBox.php
+++ b/src/Bootstrap/Elements/CheckBox.php
@@ -114,7 +114,7 @@ class CheckBox extends ControlWrapper
             $element = $element->addChild(
                 Label::create()
                      ->for($element->getControlAttribute('id'))
-                     ->text($element->description)
+                     ->html($element->description)
                      ->addClass('custom-control-label'));
         }
 

--- a/src/Bootstrap/Elements/Radio.php
+++ b/src/Bootstrap/Elements/Radio.php
@@ -111,7 +111,7 @@ class Radio extends ControlWrapper
             $element = $element->addChild(
                 Label::create()
                      ->for($element->getControlAttribute('id'))
-                     ->text($element->description)
+                     ->html($element->description)
                      ->addClass('custom-control-label'));
         }
 

--- a/tests/Forms/InputTest.php
+++ b/tests/Forms/InputTest.php
@@ -35,4 +35,40 @@ class InputTest extends HtmlTestCase
         // Assert
         $this->assertContains('value="john"', $html);
     }
+
+    /**
+     * @test
+     */
+    public function radio_and_checkboxes_inputs_displays_plain_text_and_html_in_the_description()
+    {
+        $this->openFakeForm();
+
+        // radio inputs
+        $html = bs()->radio('name', 'this description is plain text')->render()->toHtml();
+        $this->assertContains('this description is plain text', $html);
+
+        $html = bs()->radio('name', 'this description contains <a href="#">html</a>')->render()->toHtml();
+        $this->assertContains('this description contains <a href="#">html</a>', $html);
+        $this->assertNotContains('&quot;', $html); // does not contain encoded html
+
+        // checkbox inputs
+        $html = bs()->checkBox('name', 'this description is plain text')->render()->toHtml();
+        $this->assertContains('this description is plain text', $html);
+
+        $html = bs()->checkBox('name', 'this description contains <a href="#">html</a>')->render()->toHtml();
+        $this->assertContains('this description contains <a href="#">html</a>', $html);
+        $this->assertNotContains('&quot;', $html); // does not contain encoded html
+
+        // radio groups
+        $options = ['text only 1', 'text only 2'];
+        $html = bs()->radioGroup('name', $options)->render()->toHtml();
+        $this->assertContains('text only 1', $html);
+        $this->assertContains('text only 2', $html);
+
+        $options = ['with <a href="#">html</a> 1', 'with <a href="#">html</a> 2'];
+        $html = bs()->radioGroup('name', $options)->render()->toHtml();
+        $this->assertContains('with <a href="#">html</a> 1', $html);
+        $this->assertContains('with <a href="#">html</a> 2', $html);
+        $this->assertNotContains('&quot;', $html); // does not contain encoded html
+    }
 }


### PR DESCRIPTION
note that I needed to use:

```
"phpunit/phpunit": "^7.0",
"orchestra/testbench": "^3.6"
```

to actually install the package locally and run tests.
This also matches L56 requirements.

other (unrelated) tests where failing, so I only ran the tests in `InputTests.php`