### PR TITLE
Field name array fix

### DIFF
--- a/src/Bootstrap/Elements/RadioGroup.php
+++ b/src/Bootstrap/Elements/RadioGroup.php
@@ -150,7 +150,7 @@ class RadioGroup extends Div implements ShowsErrors
             ->addChildren($radios,
                 function ($radio) {
                     return $radio
-                         ->checked($this->getFieldValue($this->name, $this->selectedOption) == $radio->getValue())
+                        ->checked($this->getFieldValue($this->name, $this->selectedOption) == $radio->getValue())
                         ->name($this->name)
                         ->inline($this->inline);
                 })

--- a/src/Bootstrap/Elements/RadioGroup.php
+++ b/src/Bootstrap/Elements/RadioGroup.php
@@ -150,7 +150,7 @@ class RadioGroup extends Div implements ShowsErrors
             ->addChildren($radios,
                 function ($radio) {
                     return $radio
-                        ->checked($this->getFieldValue($this->name, $this->selectedOption === $radio->getValue()))
+                         ->checked($this->getFieldValue($this->name, $this->selectedOption) == $radio->getValue())
                         ->name($this->name)
                         ->inline($this->inline);
                 })

--- a/src/Bootstrap/Forms/FormState.php
+++ b/src/Bootstrap/Forms/FormState.php
@@ -55,21 +55,30 @@ class FormState implements FormStateContract
         return $this->oldInput->get($name, $default);
     }
 
+    public static function getSafeName($name)
+    {
+        $name = str_replace('[', '.', $name);
+        $name = str_replace(']', '', $name);
+
+        return $name;
+    }
+
     public function hasFieldErrors($name): bool
     {
-        $all = $this->errors->all($name);
+
+        $all = $this->errors->all(self::getSafeName($name));
 
         return !empty($all);
     }
 
     public function getFieldErrors($name)
     {
-        return $this->errors->all($name);
+        return $this->errors->all(self::getSafeName($name));
     }
 
     public function getFieldError($name)
     {
-        return $this->errors->first($name);
+        return $this->errors->first(self::getSafeName($name));
     }
 
     public function setHideErrors($shouldHideErrors)

--- a/src/Bootstrap/Forms/FormState.php
+++ b/src/Bootstrap/Forms/FormState.php
@@ -55,30 +55,21 @@ class FormState implements FormStateContract
         return $this->oldInput->get($name, $default);
     }
 
-    public static function getSafeName($name)
-    {
-        $name = str_replace('[', '.', $name);
-        $name = str_replace(']', '', $name);
-
-        return $name;
-    }
-
     public function hasFieldErrors($name): bool
     {
-
-        $all = $this->errors->all(self::getSafeName($name));
+        $all = $this->errors->all($name);
 
         return !empty($all);
     }
 
     public function getFieldErrors($name)
     {
-        return $this->errors->all(self::getSafeName($name));
+        return $this->errors->all($name);
     }
 
     public function getFieldError($name)
     {
-        return $this->errors->first(self::getSafeName($name));
+        return $this->errors->first($name);
     }
 
     public function setHideErrors($shouldHideErrors)


### PR DESCRIPTION
If field names are arrays, the errors aren't reported as Laravel changes it from

field[0] to field.0. 

This PR fixes that. 